### PR TITLE
Ejercicio 5 - Inversión de prioridad

### DIFF
--- a/Entrega2/code/Makefile.common
+++ b/Entrega2/code/Makefile.common
@@ -43,7 +43,7 @@ THREAD_HDR = threads/condition.hh             \
              threads/sys_info.hh              \
              threads/system.hh                \
              threads/thread.hh                \
-			 threads/prio_array.hh            \
+             threads/prio_array.hh            \
              threads/thread_test.hh           \
              threads/thread_test_garden.hh    \
              threads/thread_test_prod_cons.hh \
@@ -54,7 +54,7 @@ THREAD_HDR = threads/condition.hh             \
              lib/debug_opts.hh                \
              lib/list.hh                      \
              lib/utility.hh                   \
-			 lib/bitmap.hh                    \
+             lib/bitmap.hh                    \
              machine/interrupt.hh             \
              machine/system_dep.hh            \
              machine/statistics.hh            \
@@ -77,7 +77,7 @@ THREAD_SRC = threads/main.cc                  \
              lib/assert.cc                    \
              lib/debug.cc                     \
              lib/utility.cc                   \
-			 lib/bitmap.cc                    \
+             lib/bitmap.cc                    \
              machine/interrupt.cc             \
              machine/system_dep.cc            \
              machine/statistics.cc            \

--- a/Entrega2/code/Makefile.common
+++ b/Entrega2/code/Makefile.common
@@ -43,6 +43,7 @@ THREAD_HDR = threads/condition.hh             \
              threads/sys_info.hh              \
              threads/system.hh                \
              threads/thread.hh                \
+			 threads/prio_array.hh            \
              threads/thread_test.hh           \
              threads/thread_test_garden.hh    \
              threads/thread_test_prod_cons.hh \
@@ -53,6 +54,7 @@ THREAD_HDR = threads/condition.hh             \
              lib/debug_opts.hh                \
              lib/list.hh                      \
              lib/utility.hh                   \
+			 lib/bitmap.hh                    \
              machine/interrupt.hh             \
              machine/system_dep.hh            \
              machine/statistics.hh            \
@@ -75,6 +77,7 @@ THREAD_SRC = threads/main.cc                  \
              lib/assert.cc                    \
              lib/debug.cc                     \
              lib/utility.cc                   \
+			 lib/bitmap.cc                    \
              machine/interrupt.cc             \
              machine/system_dep.cc            \
              machine/statistics.cc            \

--- a/Entrega2/code/lib/bitmap.cc
+++ b/Entrega2/code/lib/bitmap.cc
@@ -64,6 +64,19 @@ Bitmap::Test(unsigned which) const
     return map[which / BITS_IN_WORD] & 1 << which % BITS_IN_WORD;
 }
 
+/// Find first set bit in bitmap and return one plus its index or
+/// zero if there is no set bit.
+unsigned
+Bitmap::FindFirstBit() const
+{
+    unsigned idx;
+    for (unsigned i = 0; i < numWords; i++) {
+        if ((idx = __builtin_ffs(map[i])))
+            return (i * BITS_IN_WORD) + idx;
+    }
+    return 0;
+}
+
 /// Return the number of the first bit which is clear.  As a side effect, set
 /// the bit (mark it as in use).  (In other words, find and allocate a bit.)
 ///
@@ -111,6 +124,7 @@ Bitmap::Print() const
     printf("\n");
 }
 
+#ifdef FILESYS
 /// Initialize the contents of a bitmap from a Nachos file.
 ///
 /// Note: this is not needed until the *FILESYS* assignment.
@@ -134,3 +148,4 @@ Bitmap::WriteBack(OpenFile *file) const
     ASSERT(file != nullptr);
     file->WriteAt((char *) map, numWords * sizeof (unsigned), 0);
 }
+#endif

--- a/Entrega2/code/lib/bitmap.hh
+++ b/Entrega2/code/lib/bitmap.hh
@@ -19,7 +19,10 @@
 
 
 #include "utility.hh"
+
+#ifdef FILESYS
 #include "filesys/open_file.hh"
+#endif
 
 
 /// A “bitmap” -- an array of bits, each of which can be independently set,
@@ -50,6 +53,11 @@ public:
     /// Is the “nth” bit set?
     bool Test(unsigned which) const;
 
+    /// Return the index of the first set bit plus one.
+    ///
+    /// If no bits are set, return 0.
+    unsigned FindFirstBit() const;
+
     /// Return the index of a clear bit, and as a side effect, set the bit.
     ///
     /// If no bits are clear, return -1.
@@ -61,6 +69,7 @@ public:
     /// Print contents of bitmap.
     void Print() const;
 
+#ifdef FILESYS
     /// Fetch contents from disk.
     ///
     /// Note: this is not needed until the *FILESYS* assignment, when we will
@@ -72,6 +81,7 @@ public:
     /// Note: this is not needed until the *FILESYS* assignment, when we will
     /// need to read and write the bitmap to a file.
     void WriteBack(OpenFile *file) const;
+#endif
 
 private:
 

--- a/Entrega2/code/threads/condition.cc
+++ b/Entrega2/code/threads/condition.cc
@@ -25,13 +25,13 @@
 Condition::Condition(const char *debugName, Lock *conditionLock_)
 {
     name = debugName;
-	conditionLock = conditionLock_;
-	queue = new PrioArray<Semaphore*>;
+    conditionLock = conditionLock_;
+    queue = new PrioArray<Semaphore*>;
 }
 
 Condition::~Condition()
 {
-	delete queue;
+    delete queue;
 }
 
 const char *
@@ -72,7 +72,7 @@ Condition::Broadcast()
     ASSERT(conditionLock->IsHeldByCurrentThread());
 
     Semaphore *semaphore;
-	while ((semaphore = queue->Pop())) {
+    while ((semaphore = queue->Pop())) {
         semaphore->V();
-	}
+    }
 }

--- a/Entrega2/code/threads/condition.cc
+++ b/Entrega2/code/threads/condition.cc
@@ -16,16 +16,17 @@
 
 
 #include "condition.hh"
-
+#include "system.hh"
 #include "semaphore.hh"
 
 /// Note -- without a correct implementation of `Condition::Wait`, the test
 /// case in the network assignment will not work!
 
-Condition::Condition(const char *debugName, Lock *conditionLock)
+Condition::Condition(const char *debugName, Lock *conditionLock_)
 {
-	this->conditionLock = conditionLock;
-	queue = new List<Semaphore*>();
+    name = debugName;
+	conditionLock = conditionLock_;
+	queue = new PrioArray<Semaphore*>;
 }
 
 Condition::~Condition()
@@ -42,41 +43,36 @@ Condition::GetName() const
 void
 Condition::Wait()
 {
-	Semaphore* semaphore = new Semaphore("Wait", 0);
-	Enqueue(semaphore);
-	semaphore->P();
-	delete semaphore;
+    ASSERT(conditionLock->IsHeldByCurrentThread());
+
+    Semaphore *semaphore = new Semaphore(name, 0);
+    queue->Append(semaphore, currentThread->GetPriority());
+
+    conditionLock->Release();
+    semaphore->P();
+    conditionLock->Acquire();
+    
+    delete semaphore;
 }
 
 void
 Condition::Signal()
 {
-	auto semaphore = Dequeue();
-	semaphore->V();
+    ASSERT(conditionLock->IsHeldByCurrentThread());
+
+    Semaphore *semaphore;
+    if ((semaphore = queue->Pop())) {
+        semaphore->V();
+    }
 }
 
 void
 Condition::Broadcast()
 {
-	while (!QueueIsEmpty()) {
-		Signal();
+    ASSERT(conditionLock->IsHeldByCurrentThread());
+
+    Semaphore *semaphore;
+	while ((semaphore = queue->Pop())) {
+        semaphore->V();
 	}
-}
-
-void
-Condition::Enqueue(Semaphore* semaphore)
-{
-	queue->Append(semaphore);
-}
-
-Semaphore*
-Condition::Dequeue()
-{
-	return queue->Pop();
-}
-
-bool
-Condition::QueueIsEmpty()
-{
-	return queue->IsEmpty();
 }

--- a/Entrega2/code/threads/condition.hh
+++ b/Entrega2/code/threads/condition.hh
@@ -18,7 +18,7 @@
 #define NACHOS_THREADS_CONDITION__HH
 
 #include "lock.hh"
-#include "lib/list.hh"
+#include "prio_array.hh"
 
 class Semaphore;
 
@@ -76,16 +76,16 @@ public:
 
 private:
 
-	void Enqueue(Semaphore* semaphore);
-	Semaphore* Dequeue();
-	bool QueueIsEmpty();
-
+    /// Condition name
     const char *name;
 
-	Lock* conditionLock;
-	List<Semaphore*> *queue;
+    /// Condition lock ensuring mutual exclusion on some condition.
+    /// This lock is also used to ensure mutual exclusion when manupilating the
+    /// queue.
+	Lock *conditionLock;
 
-    // Other needed fields are to be added here.
+    /// Queue of semaphores with their thread priority.
+    PrioArray<Semaphore*> *queue;
 };
 
 

--- a/Entrega2/code/threads/condition.hh
+++ b/Entrega2/code/threads/condition.hh
@@ -82,7 +82,7 @@ private:
     /// Condition lock ensuring mutual exclusion on some condition.
     /// This lock is also used to ensure mutual exclusion when manupilating the
     /// queue.
-	Lock *conditionLock;
+    Lock *conditionLock;
 
     /// Queue of semaphores with their thread priority.
     PrioArray<Semaphore*> *queue;

--- a/Entrega2/code/threads/lock.hh
+++ b/Entrega2/code/threads/lock.hh
@@ -45,8 +45,11 @@ public:
     /// Operations on the lock.
     ///
     /// Both must be *atomic*.
-    void Acquire(bool prioInheritance=false);
+    void Acquire();
     void Release();
+
+    /// Set the `prioInherit` flag on the lock.
+    void SetPrioInherit();
 
     /// Returns `true` if the current thread is the one that possesses the
     /// lock.
@@ -59,8 +62,17 @@ private:
     /// For debugging.
     const char *name;
 
-	Semaphore *semaphore;
-	Thread *held_by;
+    /// A semaphore initialized in one.
+    Semaphore *semaphore;
+
+    /// Current holder of the lock.
+    Thread *holder;
+
+    /// Priority inheritance flag.
+    bool prioInherit;
+
+    /// Previous priority of a process promoted by priority inheritance.
+    unsigned savedPrio;
 };
 
 

--- a/Entrega2/code/threads/prio_array.hh
+++ b/Entrega2/code/threads/prio_array.hh
@@ -1,0 +1,133 @@
+#ifndef NACHOS_PRIO_ARRAY__HH
+#define NACHOS_PRIO_ARRAY__HH
+
+#include "lib/bitmap.hh"
+#include "lib/list.hh"
+#include "lib/utility.hh"
+
+#include <stdio.h>
+
+/// Maximum array priority
+static const unsigned MAX_PRIO = 140;
+
+template<class Item>
+class PrioArray {
+public:
+    /// Initialize `PrioArray`.
+    PrioArray();
+
+    /// De-initialize `PrioArray`.
+    ~PrioArray();
+
+    /// Pop the highest priority item on the array.
+    Item Pop();
+
+    /// Append a item to the list with `priority`.
+    ///
+    /// * `item` is the item to be put on the array.
+    /// * `priority` is the item priority.
+    void Append(Item item, unsigned priority);
+
+    /// Remove item from `PrioArray`.
+    ///
+    /// * `item` is the item to be removed from the array.
+    /// * `priority` is the item priority.
+    void Remove(Item item, unsigned priority);
+
+    /// Print the contents of `PrioArray`.
+    ///
+    /// * `ItemPrint` is a function for printing items.
+    void Print(void (*ItemPrint)(Item)) const;
+
+    /// Return `true` if the array is empty.
+    bool IsEmpty() const;
+
+private:
+    /// List of queues for every priority.
+    List<Item> *queue;
+
+    /// Bitmap of priorities in the array.
+    Bitmap       *bitmap;
+};
+
+/// Initialize `PrioArray`.
+template<class Item>
+PrioArray<Item>::PrioArray()
+{
+    queue  = new List<Item>[MAX_PRIO];
+    bitmap = new Bitmap(MAX_PRIO);
+}
+
+/// De-initialize `PrioArray`.
+template<class Item>
+PrioArray<Item>::~PrioArray()
+{
+    delete[] queue;
+    delete   bitmap;
+}
+
+/// Pop the highest priority item on the array.
+template<class Item>
+Item
+PrioArray<Item>::Pop()
+{
+    unsigned idx;
+    if ((idx = bitmap->FindFirstBit())) {
+        idx -= 1;
+        Item highest = queue[idx].Pop();
+        if (queue[idx].IsEmpty())
+            bitmap->Clear(idx);
+        return highest;
+    }
+    return nullptr;
+}
+
+/// Append a item to the list with `priority`.
+///
+/// * `item` is the item to be put on the array.
+/// * `priority` is the item priority.
+template<class Item>
+void
+PrioArray<Item>::Append(Item item, unsigned priority)
+{
+    ASSERT(priority < MAX_PRIO);
+    queue[priority].Append(item);
+    bitmap->Mark(priority);
+}
+
+/// Remove item with `priority`.
+///
+/// * `item` is the item to be removed from the array.
+/// * `priority` is the item priority.
+template<class Item>
+void
+PrioArray<Item>::Remove(Item item, unsigned priority)
+{
+    ASSERT(priority < MAX_PRIO);
+    queue[priority].Remove(item);
+    if (queue[priority].IsEmpty())
+        bitmap->Clear(priority);
+}
+
+/// Return true if `PrioArray` is empty
+template<class Item>
+bool
+PrioArray<Item>::IsEmpty() const
+{
+    return (bitmap->FindFirstBit() == 0);
+}
+
+/// Print the contents of `PrioArray`.
+template<class Item>
+void
+PrioArray<Item>::Print(void (*ItemPrint)(Item)) const
+{
+    for (unsigned prio = 0; prio < MAX_PRIO; prio++) {
+        if (!(queue[prio].IsEmpty())) {
+            printf("\n[%d] ", prio);
+            queue[prio].Apply(ItemPrint);
+        }
+    }
+}
+
+#endif

--- a/Entrega2/code/threads/scheduler.cc
+++ b/Entrega2/code/threads/scheduler.cc
@@ -25,49 +25,16 @@
 #include <stdio.h>
 #include <string.h>
 
-const unsigned BITS_LONG = sizeof(long) * BITS_IN_BYTE;
-const unsigned BITMAP_SIZE = DivRoundUp(MAX_PRIO, BITS_LONG);
-
 /// Initialize the list of ready but not running threads to empty.
 Scheduler::Scheduler()
 {
-    readyList = new List<Thread *>[MAX_PRIO];
-    bitmap    = new unsigned long[BITMAP_SIZE];
-    memset(bitmap, 0, BITMAP_SIZE);
+    readyList = new PrioArray<Thread*>;
 }
 
 /// De-allocate the list of ready threads.
 Scheduler::~Scheduler()
 {
-    delete[] readyList;
-    delete[] bitmap;
-}
-
-/// Set bit in the bitmap signaling ready threads.
-inline void
-Scheduler::SetBit(int bit)
-{
-    bitmap[bit/BITS_LONG] |= 1UL << (bit%BITS_LONG);
-}
-
-/// Reset bit in the bitmap signaling no more threads
-inline void
-Scheduler::ResetBit(int bit)
-{
-    bitmap[bit/BITS_LONG] &= ~(1UL << (bit%BITS_LONG));
-}
-
-/// Find first set bit in bitmap and return one plus its index or
-/// zero if there is no set bit.
-int
-Scheduler::FindFirstBit()
-{
-    int idx;
-    for (unsigned i = 0; i < BITMAP_SIZE; i++) {
-        if ((idx = __builtin_ffsl(bitmap[i])))
-            return (i * BITS_LONG) + idx;
-    }
-    return 0;
+    delete readyList;
 }
 
 /// Mark a thread as ready, but not running.
@@ -81,12 +48,8 @@ Scheduler::ReadyToRun(Thread *thread)
 
     DEBUG('t', "Putting thread %s on ready list\n", thread->GetName());
 
-    unsigned    priority = thread->GetPriority();
-    List<Thread*> *queue = readyList + priority;
-
     thread->SetStatus(READY);
-    queue->Append(thread);
-    SetBit(priority);
+    readyList->Append(thread, thread->GetPriority());
 }
 
 /// Return the next thread to be scheduled onto the CPU.
@@ -97,17 +60,7 @@ Scheduler::ReadyToRun(Thread *thread)
 Thread *
 Scheduler::FindNextToRun()
 {
-    int idx;
-    if ((idx = FindFirstBit())) {
-        List<Thread*> *queue = readyList + idx - 1;
-        ASSERT(!(queue->IsEmpty()));
-
-        Thread *nextThread = queue->Pop();
-        if (queue->IsEmpty())
-            ResetBit(idx - 1);
-        return nextThread;
-    }
-    return nullptr;
+    return readyList->Pop();
 }
 
 /// Dispatch the CPU to `nextThread`.
@@ -178,12 +131,8 @@ Scheduler::Reschedule(Thread *thread, unsigned oldPrio)
 {
     unsigned newPrio = thread->GetPriority();
 
-    readyList[oldPrio].Remove(thread);
-    if (readyList[oldPrio].IsEmpty())
-        ResetBit(oldPrio);
-
-    readyList[newPrio].Append(thread);
-    SetBit(newPrio);
+    readyList->Remove(thread, oldPrio);
+    readyList->Append(thread, newPrio);
 }
 
 /// Print the scheduler state -- in other words, the contents of the ready
@@ -201,10 +150,5 @@ void
 Scheduler::Print()
 {
     printf("Ready list contents:\n");
-    for (unsigned prio = 0; prio < MAX_PRIO; prio++) {
-        if (!(readyList[prio].IsEmpty())) {
-            printf("\n[%d] ", prio);
-            readyList[prio].Apply(ThreadPrint);
-        }
-    }
+    readyList->Print(ThreadPrint);
 }

--- a/Entrega2/code/threads/scheduler.hh
+++ b/Entrega2/code/threads/scheduler.hh
@@ -10,11 +10,10 @@
 #ifndef NACHOS_THREADS_SCHEDULER__HH
 #define NACHOS_THREADS_SCHEDULER__HH
 
-
 #include "thread.hh"
-#include "lib/list.hh"
+#include "prio_array.hh"
 
-static const unsigned MAX_PRIO = 140;
+class Thread;
 
 /// The following class defines the scheduler/dispatcher abstraction --
 /// the data structures and operations needed to keep track of which
@@ -44,13 +43,9 @@ public:
     void Print();
 
 private:
-    
-    List<Thread*> *readyList;
-    unsigned long *bitmap;
 
-    void SetBit(int bit);
-    void ResetBit(int bit);
-    int FindFirstBit();
+    /// Threads ready.
+    PrioArray<Thread*> *readyList;
 
 };
 

--- a/Entrega2/code/threads/semaphore.cc
+++ b/Entrega2/code/threads/semaphore.cc
@@ -33,7 +33,7 @@ Semaphore::Semaphore(const char *debugName, int initialValue)
 {
     name  = debugName;
     value = initialValue;
-    queue = new List<Thread *>;
+    queue = new PrioArray<Thread*>;
 }
 
 /// De-allocate semaphore, when no longer needed.
@@ -64,7 +64,7 @@ Semaphore::P()
       // Disable interrupts.
 
     while (value == 0) {  // Semaphore not available.
-        queue->Append(currentThread);  // So go to sleep.
+        queue->Append(currentThread, currentThread->GetPriority());  // So go to sleep.
         currentThread->Sleep();
     }
     value--;  // Semaphore available, consume its value.

--- a/Entrega2/code/threads/semaphore.hh
+++ b/Entrega2/code/threads/semaphore.hh
@@ -21,8 +21,9 @@
 
 
 #include "thread.hh"
-#include "lib/list.hh"
+#include "prio_array.hh"
 
+class Thread;
 
 /// This class defines a “semaphore”, which has a positive integer as its
 /// value.
@@ -64,7 +65,7 @@ private:
     int value;
 
     /// Queue of threads waiting on `P` because the value is zero.
-    List<Thread *> *queue;
+    PrioArray<Thread*> *queue;
 
 };
 

--- a/Entrega2/code/threads/thread_test_prio.cc
+++ b/Entrega2/code/threads/thread_test_prio.cc
@@ -12,17 +12,17 @@
 void
 SimpleSimpleThread(void *name_)
 {
-	// Reinterpret arg `name` as a string.
-	char *name = (char *) name_;
+    // Reinterpret arg `name` as a string.
+    char *name = (char *) name_;
 
-	// If the lines dealing with interrupts are commented, the code will
-	// behave incorrectly, because printf execution may cause race
-	// conditions.
-	for (unsigned num = 0; num < 10; num++) {
-		printf("*** Thread `%s` is running: iteration %u\n", name, num);
-		currentThread->Yield();
-	}
-	printf("!!! Thread `%s` has finished\n", name);
+    // If the lines dealing with interrupts are commented, the code will
+    // behave incorrectly, because printf execution may cause race
+    // conditions.
+    for (unsigned num = 0; num < 10; num++) {
+        printf("*** Thread `%s` is running: iteration %u\n", name, num);
+        currentThread->Yield();
+    }
+    printf("!!! Thread `%s` has finished\n", name);
 }
 
 /// Set up a ping-pong between several threads but with priorities.

--- a/Entrega2/code/threads/thread_test_prio.cc
+++ b/Entrega2/code/threads/thread_test_prio.cc
@@ -68,7 +68,7 @@ void
 DataBus(void *dataBusLock_)
 {
     Lock *dataBusLock = (Lock *) dataBusLock_;
-    dataBusLock->Acquire(true);
+    dataBusLock->Acquire();
     printf("*** Data bus liberated\n");
     dataBusLock->Release();
 }
@@ -99,6 +99,7 @@ ThreadTestInversion()
     dataBus->Nice(-10);
 
     Lock *dataBusLock = new Lock("Data Bus Lock");
+    dataBusLock->SetPrioInherit();
     weather->Fork(Weather, (void *) dataBusLock);
     currentThread->Yield();
 

--- a/Entrega2/respuestas.txt
+++ b/Entrega2/respuestas.txt
@@ -1,0 +1,6 @@
+Ejercicio 5 - b
+
+El problema de inversion de prioridad no puede evitarse en el caso de los
+semaforos porque no podemos saber que proceso va a postear a un semaforo que
+esta bloqueando otros procesos importantes y no podemos incrementar la prioridad
+de ningun proceso.


### PR DESCRIPTION
Arregla el problema de inversión de prioridad hasta donde entiendo.
En resumen evita una inversión de prioridad si varios procesos están esperando un semáforo o una variable de condición. Y evita inversiones de prioridad en locks usando herencia.