### PR TITLE
Wip multiprog

### DIFF
--- a/Entrega3/code/Makefile.common
+++ b/Entrega3/code/Makefile.common
@@ -95,6 +95,8 @@ USERPROG_HDR = userprog/address_space.hh            \
                filesys/file_system.hh               \
                filesys/open_file.hh                 \
                lib/bitmap.hh                        \
+							 lib/table.hh                         \
+							 threads/thread_map.hh                \
                machine/console.hh                   \
                machine/encoding.hh                  \
                machine/endianness.hh                \
@@ -103,7 +105,7 @@ USERPROG_HDR = userprog/address_space.hh            \
                machine/machine.hh                   \
                machine/mmu.hh                       \
                machine/translation_entry.hh         \
-               userprog/synch_console.hh	       
+               userprog/synch_console.hh	        
 USERPROG_SRC = userprog/address_space.cc            \
                userprog/args.cc                     \
                userprog/debugger.cc                 \

--- a/Entrega3/code/lib/table.hh
+++ b/Entrega3/code/lib/table.hh
@@ -19,9 +19,6 @@ public:
     /// Construct an empty table.
     Table();
 
-    // Destroy table contents.
-    ~Table();
-
     /// Add an item into a free index.
     ///
     /// Returns -1 if no space is left to add the item.
@@ -69,15 +66,6 @@ Table<T>::Table()
 {
     current = 0;
 }
-
-template <class T>
-Table<T>::~Table()
-{
-    for (int i = 0; i < current; i++) {
-        delete data[i];
-    }
-}
-
 
 template <class T>
 int

--- a/Entrega3/code/lib/utility.hh
+++ b/Entrega3/code/lib/utility.hh
@@ -23,8 +23,8 @@ const unsigned BITS_IN_WORD = 32;
 
 /// Miscellaneous useful routines.
 
-//#define min(a, b)  (((a) < (b)) ? (a) : (b))
-//#define max(a, b)  (((a) > (b)) ? (a) : (b))
+#define min(a, b)  (((a) < (b)) ? (a) : (b))
+#define max(a, b)  (((a) > (b)) ? (a) : (b))
 
 /// Divide and either round up or down.
 

--- a/Entrega3/code/threads/system.cc
+++ b/Entrega3/code/threads/system.cc
@@ -30,6 +30,7 @@ Statistics *stats;            ///< Performance metrics.
 Timer *timer;                 ///< The hardware timer device, for invoking
                               ///< context switches.
 
+
 // 2007, Jose Miguel Santos Espino
 PreemptiveScheduler *preemptiveScheduler = nullptr;
 const long long DEFAULT_TIME_SLICE = 50000;
@@ -44,6 +45,9 @@ SynchDisk *synchDisk;
 
 #ifdef USER_PROGRAM  // Requires either *FILESYS* or *FILESYS_STUB*.
 Machine *machine;  ///< User program memory and registers.
+
+/// Global map for thread ids.
+ThreadMap *threadMap;
 #endif
 
 #ifdef NETWORK
@@ -229,6 +233,7 @@ Initialize(int argc, char **argv)
     Debugger *d = debugUserProg ? new Debugger : nullptr;
     machine = new Machine(d);  // This must come first.
     SetExceptionHandlers();
+    threadMap = new ThreadMap; // Global map for thread ids.
 #endif
 
 #ifdef FILESYS

--- a/Entrega3/code/threads/system.cc
+++ b/Entrega3/code/threads/system.cc
@@ -48,6 +48,7 @@ Machine *machine;  ///< User program memory and registers.
 
 /// Global map for thread ids.
 ThreadMap *threadMap;
+Bitmap *physPages;
 #endif
 
 #ifdef NETWORK
@@ -214,6 +215,10 @@ Initialize(int argc, char **argv)
 
     threadToBeDestroyed = nullptr;
 
+#ifdef USER_PROGRAM
+    threadMap = new ThreadMap; // Global map for thread ids.
+#endif
+
     // We did not explicitly allocate the current thread we are running in.
     // But if it ever tries to give up the CPU, we better have a `Thread`
     // object to save its state.
@@ -233,7 +238,7 @@ Initialize(int argc, char **argv)
     Debugger *d = debugUserProg ? new Debugger : nullptr;
     machine = new Machine(d);  // This must come first.
     SetExceptionHandlers();
-    threadMap = new ThreadMap; // Global map for thread ids.
+    physPages = new Bitmap(NUM_PHYS_PAGES);
 #endif
 
 #ifdef FILESYS
@@ -264,6 +269,8 @@ Cleanup()
 
 #ifdef USER_PROGRAM
     delete machine;
+    delete threadMap;
+    delete physPages;
 #endif
 
 #ifdef FILESYS_NEEDED

--- a/Entrega3/code/threads/system.hh
+++ b/Entrega3/code/threads/system.hh
@@ -12,6 +12,7 @@
 #include "thread.hh"
 #include "scheduler.hh"
 #include "lib/utility.hh"
+#include "lib/bitmap.hh"
 #include "machine/interrupt.hh"
 #include "machine/statistics.hh"
 #include "machine/timer.hh"
@@ -41,6 +42,7 @@ extern Machine *machine;  // User program memory and registers.
 #include "lib/table.hh"
 typedef Table<Thread*> ThreadMap;
 extern ThreadMap *threadMap;// Global map of thread ids.
+extern Bitmap *physPages;
 #endif
 
 #ifdef FILESYS_NEEDED  // *FILESYS* or *FILESYS_STUB*.

--- a/Entrega3/code/threads/system.hh
+++ b/Entrega3/code/threads/system.hh
@@ -33,9 +33,14 @@ extern Interrupt *interrupt;         ///< Interrupt status.
 extern Statistics *stats;            ///< Performance metrics.
 extern Timer *timer;                 ///< The hardware alarm clock.
 
+
 #ifdef USER_PROGRAM
 #include "machine/machine.hh"
 extern Machine *machine;  // User program memory and registers.
+
+#include "lib/table.hh"
+typedef Table<Thread*> ThreadMap;
+extern ThreadMap *threadMap;// Global map of thread ids.
 #endif
 
 #ifdef FILESYS_NEEDED  // *FILESYS* or *FILESYS_STUB*.

--- a/Entrega3/code/threads/thread.cc
+++ b/Entrega3/code/threads/thread.cc
@@ -92,9 +92,16 @@ Thread::~Thread()
 #ifdef USER_PROGRAM
     threadMap->Remove(tid);
     delete space;
-    delete openFiles;
     ASSERT(threadsJoining->IsEmpty());
     delete threadsJoining;
+    // Cerrar archivos abiertos.
+    for (int fd = 0; fd < openFiles->SIZE; fd++) {
+        OpenFile *file = openFiles->Get(fd);
+        if (file) {
+            delete file;
+        }
+    }
+    delete openFiles;
 #endif
 }
 

--- a/Entrega3/code/threads/thread.cc
+++ b/Entrega3/code/threads/thread.cc
@@ -411,6 +411,8 @@ Thread::RemoteJoin(int *exitStatus)
 void
 Thread::Exit(int exitStatus)
 {
+    interrupt->SetLevel(INT_OFF);
+
     ASSERT(this == currentThread);
     ASSERT(space != nullptr);
 
@@ -429,7 +431,9 @@ Thread::Exit(int exitStatus)
         delete info;
     }
 
-    Finish();
+    threadToBeDestroyed = currentThread;
+    Sleep();  // Invokes `SWITCH`.
+    // Not reached.
 }
 
 

--- a/Entrega3/code/threads/thread.cc
+++ b/Entrega3/code/threads/thread.cc
@@ -51,7 +51,6 @@ Thread::Thread(const char *threadName, bool mustJoin)
     stack    = nullptr;
     status   = JUST_CREATED;
     priority = DEFAULT_PRIORITY;
-    openFiles = new Table<OpenFile*>;
     this->mustJoin = mustJoin;
     if (mustJoin) {
 		joinCounter = 0;
@@ -59,9 +58,18 @@ Thread::Thread(const char *threadName, bool mustJoin)
 		joinSem = new Semaphore(threadName, 0);
 		joinCond = new Condition(threadName, joinLock);
 	}
+    this->tid = threadMap->Add(this);//devuelve -1 si hay 20 o mas hilos.
 #ifdef USER_PROGRAM
     space    = nullptr;
+    openFiles = new Table<OpenFile*>;
+    threadsJoining = new List<JoinInfo*>;
 #endif
+}
+
+unsigned
+Thread::GetTid() const
+{
+    return tid;
 }
 
 /// De-allocate a thread.
@@ -81,9 +89,12 @@ Thread::~Thread()
         SystemDep::DeallocBoundedArray((char *) stack,
                                        STACK_SIZE * sizeof *stack);
     }
+    threadMap->Remove(tid);
 #ifdef USER_PROGRAM
     delete space;
     delete openFiles;
+    ASSERT(threadsJoining->IsEmpty());
+    delete threadsJoining;
 #endif
 }
 
@@ -352,8 +363,75 @@ Thread::Join()
 		delete joinCond;
 	}
 }
+
 #ifdef USER_PROGRAM
 #include "machine/machine.hh"
+
+/// Join a target thread. Sleeps until the thread exits its user space and
+/// returns the exit status.
+///
+/// * `target` is the thread being joined.
+int
+Thread::Join(Thread *target)
+{
+    IntStatus oldLevel = interrupt->SetLevel(INT_OFF);
+
+    ASSERT(this == currentThread);
+    DEBUG('t', "Joining thread `%s` with thread `%s`.\n", name,
+          target->GetName());
+
+    int exitStatus;
+    target->RemoteJoin(&exitStatus);
+    Sleep();// returns after target exits.
+
+    interrupt->SetLevel(oldLevel);
+    return exitStatus;
+}
+
+/// Another thread requests to be notified once this thread finishes.
+/// `currentThread` is assumed to be the applicant.
+///
+///  * `exitStatus` is a reference to memory where this thread exit code will be
+///     stored.
+void
+Thread::RemoteJoin(int *exitStatus)
+{
+    ASSERT(this != currentThread);
+
+    // Puede ser que este hilo este marcado para ser destruido.
+    JoinInfo *info = new JoinInfo;
+    info->thread = currentThread;
+    info->status = exitStatus;
+    threadsJoining->Append(info);
+}
+
+/// Exit invoked from user space.
+///
+/// * `exitStatus` is the exit code.
+void
+Thread::Exit(int exitStatus)
+{
+    ASSERT(this == currentThread);
+    ASSERT(space != nullptr);
+
+    DEBUG('t', "Thread `%s` exits with code %d.\n", name, exitStatus);
+
+    /// Complete join for pending threads.
+    while (!threadsJoining->IsEmpty()) {
+        JoinInfo *info = threadsJoining->Pop();
+
+        scheduler->ReadyToRun(info->thread);// `readyToRun` asume que las
+                                            // interrupciones estan apagadas
+        if (info->status) {
+            *info->status = exitStatus;
+        }
+
+        delete info;
+    }
+
+    Finish();
+}
+
 
 /// Save the CPU state of a user program on a context switch.
 ///

--- a/Entrega3/code/threads/thread.cc
+++ b/Entrega3/code/threads/thread.cc
@@ -58,9 +58,9 @@ Thread::Thread(const char *threadName, bool mustJoin)
 		joinSem = new Semaphore(threadName, 0);
 		joinCond = new Condition(threadName, joinLock);
 	}
-    this->tid = threadMap->Add(this);//devuelve -1 si hay 20 o mas hilos.
 #ifdef USER_PROGRAM
-    space    = nullptr;
+    this->tid = threadMap->Add(this);//devuelve -1 si hay 20 o mas hilos.
+    space     = nullptr;
     openFiles = new Table<OpenFile*>;
     threadsJoining = new List<JoinInfo*>;
 #endif
@@ -89,8 +89,8 @@ Thread::~Thread()
         SystemDep::DeallocBoundedArray((char *) stack,
                                        STACK_SIZE * sizeof *stack);
     }
-    threadMap->Remove(tid);
 #ifdef USER_PROGRAM
+    threadMap->Remove(tid);
     delete space;
     delete openFiles;
     ASSERT(threadsJoining->IsEmpty());

--- a/Entrega3/code/threads/thread_map.hh
+++ b/Entrega3/code/threads/thread_map.hh
@@ -1,0 +1,9 @@
+#ifndef NACHOS_THREADS_THREAD_MAP__HH
+#define NACHOS_THREADS_THREAD_MAP__HH
+
+#include "thread.hh"
+#include "lib/table.hh"
+
+typedef Table<Thread*> ThreadMap;
+
+#endif

--- a/Entrega3/code/userprog/address_space.cc
+++ b/Entrega3/code/userprog/address_space.cc
@@ -9,6 +9,7 @@
 #include "address_space.hh"
 #include "executable.hh"
 #include "threads/system.hh"
+#include "lib/utility.hh"
 
 #include <string.h>
 
@@ -30,7 +31,7 @@ AddressSpace::AddressSpace(OpenFile *executable_file)
     numPages = DivRoundUp(size, PAGE_SIZE);
     size = numPages * PAGE_SIZE;
 
-    ASSERT(numPages <= NUM_PHYS_PAGES);
+    ASSERT(numPages <= physPages->CountClear());
       // Check we are not trying to run anything too big -- at least until we
       // have virtual memory.
 
@@ -42,8 +43,7 @@ AddressSpace::AddressSpace(OpenFile *executable_file)
     pageTable = new TranslationEntry[numPages];
     for (unsigned i = 0; i < numPages; i++) {
         pageTable[i].virtualPage  = i;
-          // For now, virtual page number = physical page number.
-        pageTable[i].physicalPage = i;
+        pageTable[i].physicalPage = physPages->Find();
         pageTable[i].valid        = true;
         pageTable[i].use          = false;
         pageTable[i].dirty        = false;
@@ -54,26 +54,74 @@ AddressSpace::AddressSpace(OpenFile *executable_file)
 
     char *mainMemory = machine->GetMMU()->mainMemory;
 
-    // Zero out the entire address space, to zero the unitialized data
-    // segment and the stack segment.
-    memset(mainMemory, 0, size);
-
     // Then, copy in the code and data segments into memory.
     uint32_t codeSize = exe.GetCodeSize();
     uint32_t initDataSize = exe.GetInitDataSize();
-    if (codeSize > 0) {
-        uint32_t virtualAddr = exe.GetCodeAddr();
-        DEBUG('a', "Initializing code segment, at 0x%X, size %u\n",
-              virtualAddr, codeSize);
-        exe.ReadCodeBlock(&mainMemory[virtualAddr], codeSize, 0);
-    }
-    if (initDataSize > 0) {
-        uint32_t virtualAddr = exe.GetInitDataAddr();
-        DEBUG('a', "Initializing data segment, at 0x%X, size %u\n",
-              virtualAddr, initDataSize);
-        exe.ReadDataBlock(&mainMemory[virtualAddr], initDataSize, 0);
+    uint32_t uninitDataSize = exe.GetUninitDataSize();
+
+    uint32_t virtualAddr, virtualPage, offset, segmentOff, physicalPage,
+             physicalAddr, writeSize;
+
+    // Assert que el segmento TEXT esta al inicio del programa.
+    ASSERT(exe.GetCodeAddr() == 0);
+
+    virtualAddr = exe.GetCodeAddr();
+    virtualPage = virtualAddr >> 7;
+    offset      = virtualAddr & 0x7f;
+    segmentOff  = 0;
+    for (; codeSize > 0; virtualPage++) {
+        physicalPage = pageTable[virtualPage].physicalPage;
+        physicalAddr = (physicalPage << 7) + offset;
+
+        //DEBUG('a', "Initializing code segment, at 0x%X, size %u\n",
+        //      virtualAddr, codeSize);
+
+        writeSize = min(PAGE_SIZE, codeSize);
+        exe.ReadCodeBlock(&mainMemory[physicalAddr], writeSize, segmentOff);
+
+        segmentOff += writeSize;
+        codeSize   -= writeSize;
+        offset      = 0;
     }
 
+    // Assert de que son contiguos los segmentos TEXT y DATA.
+    ASSERT(initDataSize == 0 || exe.GetInitDataAddr() == virtualAddr +
+           exe.GetCodeSize());
+
+    virtualAddr = exe.GetInitDataAddr();
+    virtualPage = virtualAddr >> 7;
+    offset      = virtualAddr & 0x7f;
+    segmentOff  = 0;
+    for (; initDataSize > 0; virtualPage++) {
+        physicalPage = pageTable[virtualPage].physicalPage;
+        physicalAddr = (physicalPage << 7) + offset;
+
+        //DEBUG('a', "Initializing data segment, at 0x%X, size %u\n",
+
+        writeSize = min(PAGE_SIZE, initDataSize);
+        exe.ReadDataBlock(&mainMemory[physicalAddr], writeSize, segmentOff);
+
+        segmentOff   += writeSize;
+        initDataSize -= writeSize;
+        offset        = 0;
+    }
+
+    // Asumimos que mips buscara el segmento BSS a continuacion de DATA.
+    virtualAddr = virtualAddr + exe.GetInitDataSize();
+    virtualPage = virtualAddr >> 7;
+    offset      = virtualAddr & 0x7f;
+    for (; uninitDataSize > 0; virtualPage++) {
+        physicalPage = pageTable[virtualPage].physicalPage;
+        physicalAddr = (physicalPage << 7) + offset;
+
+        //DEBUG('a', "Initializing data segment, at 0x%X, size %u\n",
+
+        writeSize = min(PAGE_SIZE, uninitDataSize);
+        memset(&mainMemory[physicalAddr], 0, writeSize);
+
+        uninitDataSize -= writeSize;
+        offset          = 0;
+    }
 }
 
 /// Deallocate an address space.
@@ -81,6 +129,9 @@ AddressSpace::AddressSpace(OpenFile *executable_file)
 /// Nothing for now!
 AddressSpace::~AddressSpace()
 {
+    for (unsigned i = 0; i < numPages; i++) {
+        physPages->Clear(pageTable[i].physicalPage);
+    }
     delete [] pageTable;
 }
 


### PR DESCRIPTION
Implementa una primera versión de multiprogramación. Para eso crea un objeto global en system.cc que lleva las referencias de las paginas físicas que están ocupadas y libres.
Esencialmente cambia como funciona el constructor y destructor de AddressSpace.