### PR TITLE
Implementa Thread::Join usando canales

### DIFF
--- a/Entrega3/code/lib/bitmap.cc
+++ b/Entrega3/code/lib/bitmap.cc
@@ -69,10 +69,10 @@ Bitmap::Test(unsigned which) const
 unsigned
 Bitmap::FindFirstBit() const
 {
-    unsigned idx;
-    for (unsigned i = 0; i < numWords; i++) {
-        if ((idx = __builtin_ffs(map[i])))
-            return (i * BITS_IN_WORD) + idx;
+    for (unsigned i = 0; i < numBits; i++) {
+        if (Test(i)) {
+            return i+1;
+        }
     }
     return 0;
 }

--- a/Entrega3/code/threads/thread.cc
+++ b/Entrega3/code/threads/thread.cc
@@ -20,9 +20,7 @@
 #include "thread.hh"
 #include "switch.h"
 #include "system.hh"
-#include "lock.hh"
-#include "semaphore.hh"
-#include "condition.hh"
+#include "channel.hh"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -52,17 +50,16 @@ Thread::Thread(const char *threadName, bool mustJoin)
     status   = JUST_CREATED;
     priority = DEFAULT_PRIORITY;
     this->mustJoin = mustJoin;
+    hasJoined = false;
     if (mustJoin) {
-		joinCounter = 0;
-		joinLock = new Lock(threadName);
-		joinSem = new Semaphore(threadName, 0);
-		joinCond = new Condition(threadName, joinLock);
-	}
+        joinChannel = new Channel(threadName);
+    } else {
+        joinChannel = nullptr;
+    }
 #ifdef USER_PROGRAM
     this->tid = threadMap->Add(this);//devuelve -1 si hay 20 o mas hilos.
     space     = nullptr;
     openFiles = new Table<OpenFile*>;
-    threadsJoining = new List<JoinInfo*>;
 #endif
 }
 
@@ -93,8 +90,7 @@ Thread::~Thread()
     threadMap->Remove(tid);
     delete space;
     delete openFiles;
-    ASSERT(threadsJoining->IsEmpty());
-    delete threadsJoining;
+    delete joinChannel;
 #endif
 }
 
@@ -183,14 +179,11 @@ Thread::Print() const
 void
 Thread::Finish()
 {
+    // TODO: Quizá podriamos llamar Exit(0) y nada mas
+
     if (mustJoin) {
         DEBUG('t', "Joining on thread \"%s\"\n", name);
-        joinSem->P();
-        joinLock->Acquire();
-        joinCond->Broadcast();
-        joinLock->Release();
-
-        delete joinSem;
+        joinChannel->Send(0);
     }
 
     interrupt->SetLevel(INT_OFF);
@@ -343,67 +336,28 @@ Thread::GetNice() const
     return priority - DEFAULT_PRIORITY;
 }
 
-void
+int
 Thread::Join()
 {
     ASSERT(mustJoin);
 
-    joinLock->Acquire();
-	joinCounter += 1;
+    // Aca hay una condicion de carrera en hasJoined.
+    // De todas formas, hasJoined solo sirve para detectar
+    // bugs de doble-join en el kernel.
+    // Asique el unico caso en el que se puede observar la
+    // condicion es en la presencia de otro error de
+    // concurrencia en el kernel.
+    ASSERT(!hasJoined);
+    hasJoined = true;
 
-    joinSem->V();
-    joinCond->Wait();
+    int result;
+    joinChannel->Receive(&result);
 
-	joinCounter -= 1;
-	bool isLastJoin = joinCounter == 0;
-    joinLock->Release();
-
-	if (isLastJoin) {
-		delete joinLock;
-		delete joinCond;
-	}
+    return result;
 }
 
 #ifdef USER_PROGRAM
 #include "machine/machine.hh"
-
-/// Join a target thread. Sleeps until the thread exits its user space and
-/// returns the exit status.
-///
-/// * `target` is the thread being joined.
-int
-Thread::Join(Thread *target)
-{
-    IntStatus oldLevel = interrupt->SetLevel(INT_OFF);
-
-    ASSERT(this == currentThread);
-    DEBUG('t', "Joining thread `%s` with thread `%s`.\n", name,
-          target->GetName());
-
-    int exitStatus;
-    target->RemoteJoin(&exitStatus);
-    Sleep();// returns after target exits.
-
-    interrupt->SetLevel(oldLevel);
-    return exitStatus;
-}
-
-/// Another thread requests to be notified once this thread finishes.
-/// `currentThread` is assumed to be the applicant.
-///
-///  * `exitStatus` is a reference to memory where this thread exit code will be
-///     stored.
-void
-Thread::RemoteJoin(int *exitStatus)
-{
-    ASSERT(this != currentThread);
-
-    // Puede ser que este hilo este marcado para ser destruido.
-    JoinInfo *info = new JoinInfo;
-    info->thread = currentThread;
-    info->status = exitStatus;
-    threadsJoining->Append(info);
-}
 
 /// Exit invoked from user space.
 ///
@@ -411,6 +365,10 @@ Thread::RemoteJoin(int *exitStatus)
 void
 Thread::Exit(int exitStatus)
 {
+    if (mustJoin) {
+        joinChannel->Send(exitStatus);
+    }
+
     interrupt->SetLevel(INT_OFF);
 
     ASSERT(this == currentThread);
@@ -418,24 +376,10 @@ Thread::Exit(int exitStatus)
 
     DEBUG('t', "Thread `%s` exits with code %d.\n", name, exitStatus);
 
-    /// Complete join for pending threads.
-    while (!threadsJoining->IsEmpty()) {
-        JoinInfo *info = threadsJoining->Pop();
-
-        scheduler->ReadyToRun(info->thread);// `readyToRun` asume que las
-                                            // interrupciones estan apagadas
-        if (info->status) {
-            *info->status = exitStatus;
-        }
-
-        delete info;
-    }
-
     threadToBeDestroyed = currentThread;
     Sleep();  // Invokes `SWITCH`.
     // Not reached.
 }
-
 
 /// Save the CPU state of a user program on a context switch.
 ///

--- a/Entrega3/code/userprog/exception.cc
+++ b/Entrega3/code/userprog/exception.cc
@@ -262,6 +262,13 @@ SyscallHandler(ExceptionType _et)
         }
 
         case SC_EXEC: {
+            // TODO: Sería bueno tomar "mustJoin" como argumento de la syscall.
+            // Ahora nos vemos forzados a ser conservadores y pasar true.
+            //
+            // Por ejemplo, esto es un problema en `userland/shell.c`, donde no
+            // joineamos los threads que corren en segundo plano, y por lo tanto
+            // nunca se limpian sus recursos.
+
             int filenameAddr = machine->ReadRegister(4);
             int argvAddr = machine->ReadRegister(5);
 
@@ -299,7 +306,7 @@ SyscallHandler(ExceptionType _et)
             DEBUG('e', "`EXEC` pedido para el ejecutable `%s`.\n", filename);
 
             AddressSpace *space = new AddressSpace(file);
-            Thread *thread = new Thread("user process");
+            Thread *thread = new Thread("user process", true);
             thread->space = space;
             thread->Fork(RunUserProgram, argv);
 

--- a/Entrega3/code/userprog/exception.cc
+++ b/Entrega3/code/userprog/exception.cc
@@ -288,7 +288,7 @@ SyscallHandler(ExceptionType _et)
             }
 
             /// Joinear con tid.
-            int status = currentThread->Join(target);
+            int status = target->Join();
             machine->WriteRegister(2, status);
 
             break;


### PR DESCRIPTION
Unifica las dos implementaciones de `Thread::Join` y hace que `Thread::Finish` y `Thread::Exit` sean casi iguales (capaz se puede hacer finish en términos de exit???)

Esta implementación asume que nunca se llama Join dos veces sobre el mismo Thread. En el caso del kernel es razonable definir que hacerlo es un bug. Para el userspace, habría que proteger ese caso por fuera de la implementación de Thread.

Algo mas o menos directo sería quitar el thread del threadMap atomicamente cuando se hace un SC_JOIN, pero no se que tan fácil de implementar es. El syscall handler se ejecuta con las interrupciones desactivadas? en ese caso sería fácil.