### PR TITLE
Reimaginacion de coremap

### DIFF
--- a/Trunk/code/threads/system.cc
+++ b/Trunk/code/threads/system.cc
@@ -58,7 +58,8 @@ PostOffice *postOffice;
 #endif
 
 #ifdef USE_TLB
-CoreMap *coreMap;  ///< Mapa de la memoria.
+CoreMapEntry *coreMap;  ///< Mapa de la memoria.
+unsigned swapVictim;   ///< Next potential swap victim.
 #endif
 
 // External definition, to allow us to take a pointer to this function.
@@ -267,7 +268,8 @@ Initialize(int argc, char **argv)
 #endif
 
 #ifdef USE_TLB
-    coreMap = new CoreMap();
+    coreMap = new CoreMapEntry[NUM_PHYS_PAGES];
+    swapVictim = 0;
 #endif
 }
 
@@ -297,6 +299,10 @@ Cleanup()
 
 #ifdef FILESYS
     delete synchDisk;
+#endif
+
+#ifdef USE_TLB
+    delete[] coreMap;
 #endif
 
     delete timer;

--- a/Trunk/code/threads/system.hh
+++ b/Trunk/code/threads/system.hh
@@ -64,7 +64,8 @@ extern PostOffice *postOffice;
 
 #ifdef USE_TLB
 #include "vmem/core_map.hh"
-extern CoreMap *coreMap;
+extern CoreMapEntry *coreMap;
+extern unsigned swapVictim;
 #endif
 
 

--- a/Trunk/code/threads/thread.hh
+++ b/Trunk/code/threads/thread.hh
@@ -47,6 +47,9 @@
 #include "filesys/open_file.hh"
 #include "lib/table.hh"
 #endif
+#ifdef USE_TLB
+#include "vmem/swap.hh"
+#endif
 
 #include <stdint.h>
 
@@ -76,6 +79,7 @@ enum ThreadStatus {
 };
 
 class JoinInfo;
+class Swap;
 
 /// The following class defines a “thread control block” -- which represents
 /// a single thread of execution.
@@ -175,6 +179,11 @@ private:
     /// Thread identifier.
     unsigned tid;
 
+#ifdef USE_TLB
+    /// Swap file.
+    Swap *swap;
+#endif
+
 #ifdef USER_PROGRAM
     /// User-level CPU register state.
     ///
@@ -205,6 +214,9 @@ public:
     // Table of open files
     Table<OpenFile*> *openFiles;
 
+#endif
+#ifdef USE_TLB
+    Swap *GetSwap() const;
 #endif
 };
 

--- a/Trunk/code/userprog/address_space.cc
+++ b/Trunk/code/userprog/address_space.cc
@@ -258,18 +258,15 @@ AddressSpace::GetTranslationEntry(unsigned virtualPage)
         coreMap[physicalPage].tid = currentThread->GetTid();
         coreMap[physicalPage].vpn = virtualPage;
 
+        pageTable[virtualPage].base.physicalPage = physicalPage;
+        pageTable[virtualPage].base.valid = true;
+
         if (pageTable[virtualPage].swap) {
             currentThread->GetSwap()->PullSwap(virtualPage, physicalPage);
-
-            pageTable[virtualPage].base.physicalPage = physicalPage;
-            pageTable[virtualPage].base.valid = true;
-            pageTable[virtualPage].swap = false;
+            /// Dejamos la bandera swap encendida pues la copia mas reciente de
+            /// la pagina sigue en el disco.
         }
         else {
-            pageTable[virtualPage].base.physicalPage = physicalPage;
-
-            pageTable[virtualPage].base.valid = true;
-
             uint32_t const virtualStart = virtualPage * PAGE_SIZE;
             uint32_t const virtualEnd = (virtualPage + 1) * PAGE_SIZE;
 

--- a/Trunk/code/userprog/address_space.hh
+++ b/Trunk/code/userprog/address_space.hh
@@ -16,12 +16,14 @@
 
 #include "filesys/file_system.hh"
 #include "machine/translation_entry.hh"
+#ifdef USE_TLB
+#include "vmem/core_map.hh"
+#endif
 
 
 const unsigned USER_STACK_SIZE = 1024;  ///< Increase this as necessary!
 
 class Executable;
-class Swap;
 
 #ifdef USE_TLB
 class PageTableEntry {
@@ -68,30 +70,7 @@ public:
     /// Evict an entry from the machine TLB and save its metadata into the page
     /// table. Return the index evicted TLB entry.
     unsigned EvictTlb();
-
-    /// Move page to swap file; returns physical page.
-    /// * `vpn` is the virtual page number of the victim page.
-    void SwapPage(unsigned vpn);
-
-    /// Look into TLB and update page table.
-    void UpdatePageTable();
-
-    /// Get `use` bit of given virtual page.
-    /// * `vpn` is the virtual page number.
-    bool UseBit(unsigned vpn);
-
-    /// Get `dirty` bit of given virtual page.
-    /// * `vpn` is the virtual page number.
-    bool DirtyBit(unsigned vpn);
-
-    /// Clear `use` bit of given virtual page.
-    /// Used in page replacement.
-    /// `vpn` is the virtual page number.
-    void ClearUseBit(unsigned vpn);
 #endif
-
-    /// Returns address space id.
-    unsigned GetASid();
 
 private:
 
@@ -104,8 +83,6 @@ private:
     /// Number of pages in the virtual address space.
     unsigned numPages;
 
-    /// Address space id (actualmente igual al tid).
-    unsigned asid;
 #ifdef USE_TLB
     /// Executable of the program file.
     Executable *exe;
@@ -113,7 +90,9 @@ private:
     /// Next tlb victim.
     unsigned tlbVictim;
 
-    Swap *swap;
+    /// CoreMap::MoveFrameToSwap requires access to the pageTable of any
+    /// address space.
+    friend unsigned CoreMap::MoveFrameToSwap();
 #endif
 
 };

--- a/Trunk/code/vmem/core_map.cc
+++ b/Trunk/code/vmem/core_map.cc
@@ -1,3 +1,5 @@
+/// Virtual memory functionality.
+
 #include "core_map.hh"
 #include "threads/system.hh"
 
@@ -61,6 +63,9 @@ CoreMap::MoveFrameToSwap() {
                 if (victimEntry->base.dirty) {
                     victimThread->GetSwap()->WriteSwap(victimInfo->vpn,
                                                        swapVictim);
+                    /// El disco guarda una copia de la ultima version de esta
+                    /// pagina, asi que borramos el bit dirty.
+                    victimEntry->base.dirty = false;
                     victimEntry->swap = true;
                 }
 

--- a/Trunk/code/vmem/core_map.hh
+++ b/Trunk/code/vmem/core_map.hh
@@ -5,24 +5,33 @@
 
 class Thread;
 
+/// Main memory information about paging.
+///
+/// Each main memory frame pertain to an unique process and have an unique page
+/// number within that process.
 class CoreMapEntry {
 public:
-    unsigned vpn;
+    /// Process to which this frame pertains.
     unsigned tid; 
+
+    /// Page number within `tid` address space.
+    unsigned vpn;
 };
 
-class CoreMap {
-public:
-    CoreMap();
-    ~CoreMap();
-    unsigned MapPhysPage(unsigned vpn);
-    void FreeAll(unsigned tid);
+/// Virtual memory functionality.
+///
+/// A clock algorithm is used to select the next frame to be evicted from main
+/// memory and moved into swap area.
+namespace CoreMap {
+    /// Selects and moves a frame from main memory to swap.
+    ///
+    /// Returns the frame number.
+    unsigned MoveFrameToSwap();
 
-private:
-    CoreMapEntry *coreMap;
-    unsigned victim;
-    unsigned FreePage();
-    unsigned FindMatch(bool dirty);
+    /// Finds an empty frame. If there is none, moves a frame to swap.
+    ///
+    /// Returns an empty-frame number.
+    unsigned Find();
 };
 
 #endif


### PR DESCRIPTION
Refactoriza y parcialmente reinventa coremap para intentar reducir la complejidad del código. Se borra la clase CoreMap y se mueve la lógica a dos funciones: MoveFrameToSwap y Find.

Además:
- Una pagina que se marca como sucia ya no puede regresar al estado limpio... El código ya no cambia la bandera dirty.
- Swap se mueve a ser un miembro de los threads en vez de los address space.

TODO
- Documentar la clase Swap.